### PR TITLE
Fix query parsing issues 

### DIFF
--- a/httplib.h
+++ b/httplib.h
@@ -1454,8 +1454,11 @@ inline std::pair<int, int> trim(const char *b, const char *e, int left,
 template <class Fn> void split(const char *b, const char *e, char d, Fn fn) {
   int i = 0;
   int beg = 0;
+  if(!b) {
+    return;
+  }
 
-  while (e ? (b + i != e) : (b[i] != '\0')) {
+  while (e ? (b + i < e) : (b[i] != '\0')) {
     if (b[i] == d) {
       auto r = trim(b, e, beg, i);
       fn(&b[r.first], &b[r.second]);
@@ -2847,7 +2850,10 @@ inline void parse_query_text(const std::string &s, Params &params) {
         val.assign(b2, e2);
       }
     });
-    params.emplace(decode_url(key, true), decode_url(val, true));
+
+    if(!key.empty()) {
+      params.emplace(decode_url(key, true), decode_url(val, true));
+    }
   });
 }
 

--- a/httplib.h
+++ b/httplib.h
@@ -1454,14 +1454,13 @@ inline std::pair<int, int> trim(const char *b, const char *e, int left,
 template <class Fn> void split(const char *b, const char *e, char d, Fn fn) {
   int i = 0;
   int beg = 0;
-  if(!b) {
-    return;
-  }
 
   while (e ? (b + i < e) : (b[i] != '\0')) {
     if (b[i] == d) {
       auto r = trim(b, e, beg, i);
-      fn(&b[r.first], &b[r.second]);
+      if (r.first < r.second) {
+        fn(&b[r.first], &b[r.second]);
+      }
       beg = i + 1;
     }
     i++;
@@ -1469,7 +1468,9 @@ template <class Fn> void split(const char *b, const char *e, char d, Fn fn) {
 
   if (i) {
     auto r = trim(b, e, beg, i);
-    fn(&b[r.first], &b[r.second]);
+    if (r.first < r.second) {
+      fn(&b[r.first], &b[r.second]);
+    }
   }
 }
 
@@ -2835,7 +2836,6 @@ inline std::string params_to_query_str(const Params &params) {
     query += "=";
     query += encode_url(it->second);
   }
-
   return query;
 }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -66,12 +66,23 @@ TEST(SplitTest, ParseQueryString) {
   EXPECT_EQ("val3", dic.find("key3")->second);
 }
 
-TEST(SplitTest, ParseQueryWithSingleSpaceChar) {
-  string s = " ";
-  Params dict;
-  detail::parse_query_text(s, dict);
-  EXPECT_TRUE(dict.empty());
+TEST(SplitTest, ParseInvalidQueryTests) {
+
+  {
+    string s = " ";
+    Params dict;
+    detail::parse_query_text(s, dict);
+    EXPECT_TRUE(dict.empty());
+  }
+
+  {
+    string s = " = =";
+    Params dict;
+    detail::parse_query_text(s, dict);
+    EXPECT_TRUE(dict.empty());
+  }
 }
+
 
 TEST(ParseQueryTest, ParseQueryString) {
   string s = "key1=val1&key2=val2&key3=val3";

--- a/test/test.cc
+++ b/test/test.cc
@@ -66,6 +66,13 @@ TEST(SplitTest, ParseQueryString) {
   EXPECT_EQ("val3", dic.find("key3")->second);
 }
 
+TEST(SplitTest, ParseQueryWithSingleSpaceChar) {
+  string s = " ";
+  Params dict;
+  detail::parse_query_text(s, dict);
+  EXPECT_TRUE(dict.empty());
+}
+
 TEST(ParseQueryTest, ParseQueryString) {
   string s = "key1=val1&key2=val2&key3=val3";
   Params dic;


### PR DESCRIPTION
httplib::detail::split wasn't doing proper boundary checks. Inputs like  "/?  "  (query with only spaces) or   "/?= ="    were crashing the server cause of illegal memory access done by the process,  creating a potential  security vulnerability, as this could be leveraged to make a DoS attack 